### PR TITLE
Add PyQt6 Git GUI skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # git-gui
-# This repo contains code git GUI using python qt6
+
+This repository provides a minimal Git GUI application written in Python.
+The GUI uses **PyQt6** and the backend logic relies on standard git commands.
+
+## Requirements
+
+- Python 3.10+
+- PyQt6
+- Git installed and available on the command line
+
+## Running
+
+Install the required Python dependencies and run the application with
+
+```bash
+python -m pip install PyQt6
+python -m git_gui.main /path/to/repository
+```
+
+If no path is provided, the current directory is used.
+
+## Project Structure
+
+- `git_gui/git_backend.py` – minimal wrapper around git commands
+- `git_gui/app.py` – PyQt6 GUI
+- `git_gui/main.py` – command line entry point
+- `tests/` – unit tests for git backend logic
+
+## Development Notes
+
+The project aims to demonstrate basic best practices for separating the
+business logic (git operations) from the user interface. The GUI lists the
+current status of repository files, allows staging and committing changes,
+and exposes simple pull and push actions.

--- a/git_gui/app.py
+++ b/git_gui/app.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import os
+from typing import List
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QListWidget,
+    QListWidgetItem,
+    QMainWindow,
+    QMenu,
+    QMenuBar,
+    QMessageBox,
+    QTextEdit,
+    QToolBar,
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+)
+
+from .git_backend import Repository, FileStatus
+
+class GitGuiApp(QMainWindow):
+    def __init__(self, repo_path: str) -> None:
+        super().__init__()
+        self.setWindowTitle("Git GUI")
+        self.resize(800, 600)
+
+        self.repo = Repository(repo_path)
+
+        self.status_list = QListWidget()
+        self.commit_msg = QTextEdit()
+        self.log_view = QTextEdit()
+        self.log_view.setReadOnly(True)
+        self.branch_label = QLabel()
+
+        central = QWidget()
+        layout = QVBoxLayout()
+        layout.addWidget(self.branch_label)
+        layout.addWidget(self.status_list)
+        layout.addWidget(QLabel("Commit message:"))
+        layout.addWidget(self.commit_msg)
+        layout.addWidget(QLabel("Log:"))
+        layout.addWidget(self.log_view)
+        central.setLayout(layout)
+        self.setCentralWidget(central)
+
+        self._create_menu()
+        self._create_toolbar()
+        self.refresh()
+
+    def _create_menu(self) -> None:
+        menu_bar = QMenuBar()
+        file_menu = QMenu("File", self)
+        open_action = file_menu.addAction("Open Repository")
+        open_action.triggered.connect(self.open_repo)
+        exit_action = file_menu.addAction("Exit")
+        exit_action.triggered.connect(self.close)
+        menu_bar.addMenu(file_menu)
+
+        git_menu = QMenu("Git", self)
+        commit_action = git_menu.addAction("Commit")
+        commit_action.triggered.connect(self.commit)
+        pull_action = git_menu.addAction("Pull")
+        pull_action.triggered.connect(self.pull)
+        push_action = git_menu.addAction("Push")
+        push_action.triggered.connect(self.push)
+        menu_bar.addMenu(git_menu)
+
+        self.setMenuBar(menu_bar)
+
+    def _create_toolbar(self) -> None:
+        toolbar = QToolBar("Main")
+        self.addToolBar(toolbar)
+        refresh_action = toolbar.addAction("Refresh")
+        refresh_action.triggered.connect(self.refresh)
+
+    def open_repo(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Open Repository", os.getcwd())
+        if path:
+            try:
+                self.repo = Repository(path)
+                self.refresh()
+            except ValueError as exc:
+                QMessageBox.critical(self, "Error", str(exc))
+
+    def refresh(self) -> None:
+        self.status_list.clear()
+        for status in self.repo.status():
+            item = QListWidgetItem(f"{status.status}\t{status.path}")
+            item.setData(Qt.ItemDataRole.UserRole, status.path)
+            self.status_list.addItem(item)
+        self.log_view.setPlainText(self.repo.log())
+        branch = self._current_branch()
+        self.branch_label.setText(f"Branch: {branch}")
+
+    def _current_branch(self) -> str:
+        result = os.popen(f"cd '{self.repo.path}' && git rev-parse --abbrev-ref HEAD").read().strip()
+        return result
+
+    def commit(self) -> None:
+        message = self.commit_msg.toPlainText().strip()
+        if not message:
+            QMessageBox.warning(self, "Warning", "Commit message is empty")
+            return
+        paths = [self.status_list.item(i).data(Qt.ItemDataRole.UserRole) for i in range(self.status_list.count())]
+        self.repo.stage(paths)
+        self.repo.commit(message)
+        self.commit_msg.clear()
+        self.refresh()
+
+    def pull(self) -> None:
+        self.repo.pull()
+        self.refresh()
+
+    def push(self) -> None:
+        self.repo.push()
+        self.refresh()
+
+
+def run(repo_path: str) -> None:
+    app = QApplication([])
+    window = GitGuiApp(repo_path)
+    window.show()
+    app.exec()

--- a/git_gui/git_backend.py
+++ b/git_gui/git_backend.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import List, Optional
+
+@dataclass
+class FileStatus:
+    path: str
+    status: str
+
+def _run_git(cmd: List[str], cwd: str) -> subprocess.CompletedProcess:
+    return subprocess.run([
+        'git',
+        *cmd
+    ], cwd=cwd, check=False, capture_output=True, text=True)
+
+class Repository:
+    """Simple wrapper around git CLI commands."""
+
+    def __init__(self, path: str) -> None:
+        self.path = os.path.abspath(path)
+        if not os.path.isdir(os.path.join(self.path, '.git')):
+            raise ValueError(f"{path} is not a git repository")
+
+    def status(self) -> List[FileStatus]:
+        """Return status of repository files."""
+        result = _run_git(['status', '--porcelain'], self.path)
+        lines = result.stdout.splitlines()
+        statuses = []
+        for line in lines:
+            status_code = line[:2].strip()
+            file_path = line[3:]
+            statuses.append(FileStatus(path=file_path, status=status_code))
+        return statuses
+
+    def stage(self, files: List[str]) -> None:
+        if files:
+            _run_git(['add', '--'] + files, self.path)
+
+    def unstage(self, files: List[str]) -> None:
+        if files:
+            _run_git(['reset', 'HEAD', '--'] + files, self.path)
+
+    def commit(self, message: str) -> None:
+        _run_git(['commit', '-m', message], self.path)
+
+    def pull(self, remote: str = 'origin', branch: Optional[str] = None) -> None:
+        cmd = ['pull', remote]
+        if branch:
+            cmd.append(branch)
+        _run_git(cmd, self.path)
+
+    def push(self, remote: str = 'origin', branch: Optional[str] = None) -> None:
+        cmd = ['push', remote]
+        if branch:
+            cmd.append(branch)
+        _run_git(cmd, self.path)
+
+    def log(self, max_count: int = 20) -> str:
+        result = _run_git(['log', f'--max-count={max_count}', '--oneline'], self.path)
+        return result.stdout

--- a/git_gui/main.py
+++ b/git_gui/main.py
@@ -1,0 +1,14 @@
+import argparse
+import os
+from .app import run
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple Git GUI")
+    parser.add_argument('path', nargs='?', default=os.getcwd(), help='Path to git repository')
+    args = parser.parse_args()
+    run(args.path)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_git_backend.py
+++ b/tests/test_git_backend.py
@@ -1,0 +1,26 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from git_gui.git_backend import Repository
+
+class TestRepository(unittest.TestCase):
+    def create_repo(self, directory: Path) -> Path:
+        subprocess.run(['git', 'init'], cwd=directory, check=True)
+        (directory / 'file.txt').write_text('hello')
+        subprocess.run(['git', 'add', 'file.txt'], cwd=directory, check=True)
+        subprocess.run(['git', 'commit', '-m', 'init'], cwd=directory, check=True)
+        return directory
+
+    def test_status(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            self.create_repo(repo_path)
+            (repo_path / 'new.txt').write_text('new')
+            repo = Repository(str(repo_path))
+            statuses = repo.status()
+            self.assertTrue(any(s.path == 'new.txt' and s.status == '??' for s in statuses))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a minimal git backend using subprocess
- implement a basic PyQt6 GUI
- add an entrypoint for the app
- provide a unittest for the backend
- update README with usage instructions

## Testing
- `python -m unittest discover -s tests -p 'test_*.py' -v`