### PR TITLE
Add diff viewing and switch to GitPython

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # git-gui
 
 This repository provides a minimal Git GUI application written in Python.
-The GUI uses **PyQt6** and the backend logic relies on standard git commands.
+The GUI uses **PyQt6** and the backend logic relies on **GitPython**.
 
 ## Requirements
 
 - Python 3.10+
 - PyQt6
+- GitPython
 - Git installed and available on the command line
 
 ## Running
@@ -14,7 +15,7 @@ The GUI uses **PyQt6** and the backend logic relies on standard git commands.
 Install the required Python dependencies and run the application with
 
 ```bash
-python -m pip install PyQt6
+python -m pip install PyQt6 GitPython
 python -m git_gui.main /path/to/repository
 ```
 

--- a/git_gui/app.py
+++ b/git_gui/app.py
@@ -30,6 +30,7 @@ class GitGuiApp(QMainWindow):
         self.repo = Repository(repo_path)
 
         self.status_list = QListWidget()
+        self.status_list.itemDoubleClicked.connect(self._show_diff)
         self.commit_msg = QTextEdit()
         self.log_view = QTextEdit()
         self.log_view.setReadOnly(True)
@@ -102,8 +103,14 @@ class GitGuiApp(QMainWindow):
         self.branch_label.setText(f"Branch: {branch}")
 
     def _current_branch(self) -> str:
-        result = os.popen(f"cd '{self.repo.path}' && git rev-parse --abbrev-ref HEAD").read().strip()
-        return result
+        return self.repo.current_branch()
+
+    def _show_diff(self, item: QListWidgetItem) -> None:
+        path = item.data(Qt.ItemDataRole.UserRole)
+        diff = self.repo.diff(path)
+        if not diff.strip():
+            diff = 'No changes'
+        QMessageBox.information(self, 'Diff', diff)
 
     def commit(self) -> None:
         message = self.commit_msg.toPlainText().strip()

--- a/git_gui/git_backend.py
+++ b/git_gui/git_backend.py
@@ -1,32 +1,32 @@
 import os
-import subprocess
 from dataclasses import dataclass
 from typing import List, Optional
+
+from git import Repo, GitCommandError
+
 
 @dataclass
 class FileStatus:
     path: str
     status: str
 
-def _run_git(cmd: List[str], cwd: str) -> subprocess.CompletedProcess:
-    return subprocess.run([
-        'git',
-        *cmd
-    ], cwd=cwd, check=False, capture_output=True, text=True)
-
 class Repository:
-    """Simple wrapper around git CLI commands."""
+    """Wrapper around git operations using GitPython."""
 
     def __init__(self, path: str) -> None:
         self.path = os.path.abspath(path)
-        if not os.path.isdir(os.path.join(self.path, '.git')):
+        try:
+            self.repo = Repo(self.path)
+        except GitCommandError as exc:
+            raise ValueError(f"{path} is not a git repository") from exc
+        if self.repo.bare:
             raise ValueError(f"{path} is not a git repository")
 
     def status(self) -> List[FileStatus]:
         """Return status of repository files."""
-        result = _run_git(['status', '--porcelain'], self.path)
-        lines = result.stdout.splitlines()
-        statuses = []
+        output = self.repo.git.status('--porcelain')
+        lines = output.splitlines()
+        statuses: List[FileStatus] = []
         for line in lines:
             status_code = line[:2].strip()
             file_path = line[3:]
@@ -35,40 +35,45 @@ class Repository:
 
     def stage(self, files: List[str]) -> None:
         if files:
-            _run_git(['add', '--'] + files, self.path)
+            self.repo.git.add('--', *files)
 
     def unstage(self, files: List[str]) -> None:
         if files:
-            _run_git(['reset', 'HEAD', '--'] + files, self.path)
+            self.repo.git.reset('HEAD', '--', *files)
 
     def commit(self, message: str) -> None:
-        _run_git(['commit', '-m', message], self.path)
+        self.repo.git.commit('-m', message)
 
     def pull(self, remote: str = 'origin', branch: Optional[str] = None) -> None:
-        cmd = ['pull', remote]
         if branch:
-            cmd.append(branch)
-        _run_git(cmd, self.path)
+            self.repo.git.pull(remote, branch)
+        else:
+            self.repo.git.pull(remote)
 
     def push(self, remote: str = 'origin', branch: Optional[str] = None) -> None:
-        cmd = ['push', remote]
         if branch:
-            cmd.append(branch)
-        _run_git(cmd, self.path)
+            self.repo.git.push(remote, branch)
+        else:
+            self.repo.git.push(remote)
 
     def log(self, max_count: int = 20) -> str:
-        result = _run_git(['log', f'--max-count={max_count}', '--oneline'], self.path)
-        return result.stdout
+        output = self.repo.git.log(f'--max-count={max_count}', '--oneline')
+        return output
 
     def current_branch(self) -> str:
         """Return the name of the current branch."""
-        result = _run_git(['rev-parse', '--abbrev-ref', 'HEAD'], self.path)
-        return result.stdout.strip()
+        return self.repo.active_branch.name
 
     def push_review(self, remote: str = 'origin', branch: Optional[str] = None) -> str:
         """Return commits that would be pushed to the remote."""
         if branch is None:
             branch = self.current_branch()
         range_spec = f'{remote}/{branch}..HEAD'
-        result = _run_git(['log', '--oneline', range_spec], self.path)
-        return result.stdout
+        output = self.repo.git.log('--oneline', range_spec)
+        return output
+
+    def diff(self, path: str, cached: bool = False) -> str:
+        """Return diff for a given file."""
+        if cached:
+            return self.repo.git.diff('--cached', '--', path)
+        return self.repo.git.diff('--', path)

--- a/tests/test_git_backend.py
+++ b/tests/test_git_backend.py
@@ -39,5 +39,16 @@ class TestRepository(unittest.TestCase):
             review = repo.push_review(remote='origin', branch='master')
             self.assertIn('new commit', review)
 
+    def test_diff(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir)
+            self.create_repo(repo_path)
+            file_path = repo_path / 'file.txt'
+            file_path.write_text('hello world')
+            repo = Repository(str(repo_path))
+            diff = repo.diff('file.txt')
+            self.assertIn('-hello', diff)
+            self.assertIn('+hello world', diff)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- use GitPython for backend operations
- show file diff when double-clicking on a modified file
- document GitPython dependency
- test the new diff method

## Testing
- `python -m unittest tests.test_git_backend -v` *(fails: ModuleNotFoundError: No module named 'git')*