### PR TITLE
Add Qt Model/View and branch switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ If no path is provided, the current directory is used.
 - `git_gui/main.py` – command line entry point
 - `tests/` – unit tests for git backend logic
 
+## Architectural Plan
+
+The application is organized into several modules using the Qt Model/View
+pattern:
+
+- **`git_gui.git_backend`** – `Repository` wraps GitPython to expose actions
+  like status, staging, committing, pulling, pushing and branch operations.
+- **`git_gui.models`** – `FileStatusModel` implements a `QAbstractListModel`
+  to present `FileStatus` entries from the repository.
+- **`git_gui.diff_viewer`** – `DiffViewer` dialog displays diffs using simple
+  HTML styling.
+- **`git_gui.diff_highlighter`** – `DiffHighlighter` highlights diff output in
+  text widgets.
+- **`git_gui.app`** – `GitGuiApp` main window wiring together the model and
+  backend, providing actions for staging, committing, pulling and pushing.
+- **`git_gui.main`** – entry point launching the application.
+
 ## Development Notes
 
 The project aims to demonstrate basic best practices for separating the

--- a/git_gui/git_backend.py
+++ b/git_gui/git_backend.py
@@ -94,3 +94,11 @@ class Repository:
         if cached:
             return self.repo.git.diff('--cached', '--', path)
         return self.repo.git.diff('--', path)
+
+    def branches(self) -> List[str]:
+        """Return a list of branch names."""
+        return [head.name for head in self.repo.heads]
+
+    def checkout(self, branch: str) -> None:
+        """Switch to the given branch."""
+        self.repo.git.checkout(branch)

--- a/git_gui/models.py
+++ b/git_gui/models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import List
+from PyQt6.QtCore import QAbstractListModel, QModelIndex, Qt, QVariant
+
+from .git_backend import FileStatus
+
+class FileStatusModel(QAbstractListModel):
+    """Model to expose repository file status entries."""
+
+    def __init__(self, statuses: List[FileStatus] | None = None) -> None:
+        super().__init__()
+        self._statuses: List[FileStatus] = statuses or []
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole):
+        if not index.isValid() or not (0 <= index.row() < len(self._statuses)):
+            return QVariant()
+        status = self._statuses[index.row()]
+        if role == Qt.ItemDataRole.DisplayRole:
+            return f"{status.status}\t{status.path}"
+        if role == Qt.ItemDataRole.UserRole:
+            return status
+        return QVariant()
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # type: ignore[override]
+        return len(self._statuses)
+
+    def update_statuses(self, statuses: List[FileStatus]) -> None:
+        self.beginResetModel()
+        self._statuses = list(statuses)
+        self.endResetModel()
+
+    @property
+    def statuses(self) -> List[FileStatus]:
+        return list(self._statuses)
+
+    def status_at(self, index: QModelIndex) -> FileStatus | None:
+        if not index.isValid() or not (0 <= index.row() < len(self._statuses)):
+            return None
+        return self._statuses[index.row()]


### PR DESCRIPTION
## Summary
- implement FileStatusModel using Qt's model/view pattern
- refactor GUI to use QListView and FileStatusModel
- allow branch switching via combo box
- add branch helpers to git backend
- document module responsibilities

## Testing
- `python -m unittest discover -s tests -p 'test_*.py' -v` *(fails: ModuleNotFoundError: No module named 'git')*